### PR TITLE
Abstract services regenerated because of pagination problem

### DIFF
--- a/config/model-binding.php
+++ b/config/model-binding.php
@@ -601,5 +601,13 @@ return [
         return NextDeveloper\Events\Database\Models\EventListener::findByRef($value);
 },
 
+'eventavailable' => function ($value) {
+        return NextDeveloper\Events\Database\Models\EventAvailable::findByRef($value);
+},
+
+'eventlistener' => function ($value) {
+        return NextDeveloper\Events\Database\Models\EventListener::findByRef($value);
+},
+
 // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 ];

--- a/src/Database/Filters/AvailablesQueryFilter.php
+++ b/src/Database/Filters/AvailablesQueryFilter.php
@@ -12,6 +12,7 @@ use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
  */
 class AvailablesQueryFilter extends AbstractQueryFilter
 {
+
     /**
      * @var Builder
      */
@@ -27,32 +28,32 @@ class AvailablesQueryFilter extends AbstractQueryFilter
         return $this->builder->where('description', 'like', '%' . $value . '%');
     }
 
-    public function createdAtStart($date) 
+    public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
     }
 
-    public function createdAtEnd($date) 
+    public function createdAtEnd($date)
     {
         return $this->builder->where('created_at', '<=', $date);
     }
 
-    public function updatedAtStart($date) 
+    public function updatedAtStart($date)
     {
         return $this->builder->where('updated_at', '>=', $date);
     }
 
-    public function updatedAtEnd($date) 
+    public function updatedAtEnd($date)
     {
         return $this->builder->where('updated_at', '<=', $date);
     }
 
-    public function deletedAtStart($date) 
+    public function deletedAtStart($date)
     {
         return $this->builder->where('deleted_at', '>=', $date);
     }
 
-    public function deletedAtEnd($date) 
+    public function deletedAtEnd($date)
     {
         return $this->builder->where('deleted_at', '<=', $date);
     }

--- a/src/Database/Filters/ListenersQueryFilter.php
+++ b/src/Database/Filters/ListenersQueryFilter.php
@@ -12,6 +12,7 @@ use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
  */
 class ListenersQueryFilter extends AbstractQueryFilter
 {
+
     /**
      * @var Builder
      */
@@ -27,32 +28,32 @@ class ListenersQueryFilter extends AbstractQueryFilter
         return $this->builder->where('callback', 'like', '%' . $value . '%');
     }
 
-    public function createdAtStart($date) 
+    public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
     }
 
-    public function createdAtEnd($date) 
+    public function createdAtEnd($date)
     {
         return $this->builder->where('created_at', '<=', $date);
     }
 
-    public function updatedAtStart($date) 
+    public function updatedAtStart($date)
     {
         return $this->builder->where('updated_at', '>=', $date);
     }
 
-    public function updatedAtEnd($date) 
+    public function updatedAtEnd($date)
     {
         return $this->builder->where('updated_at', '<=', $date);
     }
 
-    public function deletedAtStart($date) 
+    public function deletedAtStart($date)
     {
         return $this->builder->where('deleted_at', '>=', $date);
     }
 
-    public function deletedAtEnd($date) 
+    public function deletedAtEnd($date)
     {
         return $this->builder->where('deleted_at', '<=', $date);
     }

--- a/src/Database/Models/Availables.php
+++ b/src/Database/Models/Availables.php
@@ -136,4 +136,5 @@ class Availables extends Model
 
 
 
+
 }

--- a/src/Database/Models/Listeners.php
+++ b/src/Database/Models/Listeners.php
@@ -138,4 +138,5 @@ class Listeners extends Model
 
 
 
+
 }

--- a/src/Http/Controllers/AbstractController.php
+++ b/src/Http/Controllers/AbstractController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NextDeveloper\Events\Http\Controllers;
+
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller;
+use NextDeveloper\Commons\Http\Traits\Responsable;
+
+class AbstractController extends Controller
+{
+    //  NextDeveloper Generator Traits
+    use Responsable;
+
+    //  Laravel Traits
+    use DispatchesJobs, ValidatesRequests;
+    // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+}

--- a/src/Http/Transformers/AbstractTransformers/AbstractAvailablesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAvailablesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Events\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Events\Database\Models\Availables;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class AvailablesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -12,6 +31,21 @@ use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
  */
 class AbstractAvailablesTransformer extends AbstractTransformer
 {
+
+    /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
 
     /**
      * @param Availables $model
@@ -33,7 +67,91 @@ class AbstractAvailablesTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Availables $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Availables $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Availables $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Availables $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Availables $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Availables $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Availables $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Availables $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Availables $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractListenersTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractListenersTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Events\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Events\Database\Models\Listeners;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class ListenersTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,14 +33,29 @@ class AbstractListenersTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Listeners $model
      *
      * @return array
      */
     public function transform(Listeners $model)
     {
-                        $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-        
+                                                $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -35,7 +69,91 @@ class AbstractListenersTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Listeners $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Listeners $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Listeners $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Listeners $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Listeners $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Listeners $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Listeners $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Listeners $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Listeners $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -5,6 +5,7 @@ Route::prefix('events')->group(
         Route::prefix('available')->group(
             function () {
                 Route::get('/', 'Available\AvailableController@index');
+                Route::get('/actions', 'Available\AvailableController@getActions');
 
                 Route::get('{event_available}/tags ', 'Available\AvailableController@tags');
                 Route::post('{event_available}/tags ', 'Available\AvailableController@saveTags');
@@ -15,6 +16,8 @@ Route::prefix('events')->group(
                 Route::get('/{event_available}', 'Available\AvailableController@show');
 
                 Route::post('/', 'Available\AvailableController@store');
+                Route::post('/{event_available}/do/{action}', 'Available\AvailableController@doAction');
+
                 Route::patch('/{event_available}', 'Available\AvailableController@update');
                 Route::delete('/{event_available}', 'Available\AvailableController@destroy');
             }
@@ -23,6 +26,7 @@ Route::prefix('events')->group(
         Route::prefix('listeners')->group(
             function () {
                 Route::get('/', 'Listeners\ListenersController@index');
+                Route::get('/actions', 'Listeners\ListenersController@getActions');
 
                 Route::get('{event_listeners}/tags ', 'Listeners\ListenersController@tags');
                 Route::post('{event_listeners}/tags ', 'Listeners\ListenersController@saveTags');
@@ -33,6 +37,8 @@ Route::prefix('events')->group(
                 Route::get('/{event_listeners}', 'Listeners\ListenersController@show');
 
                 Route::post('/', 'Listeners\ListenersController@store');
+                Route::post('/{event_listeners}/do/{action}', 'Listeners\ListenersController@doAction');
+
                 Route::patch('/{event_listeners}', 'Listeners\ListenersController@update');
                 Route::delete('/{event_listeners}', 'Listeners\ListenersController@destroy');
             }
@@ -51,8 +57,11 @@ Route::prefix('events')->group(
 
 
 
+
+
     }
 );
+
 
 
 


### PR DESCRIPTION
Abstract services regenerated because of pagination problem. This problem was creating a security issue. The original was of paginating the objects was with the Laravel Eloquent pagination like $model->paginate(). However this method discards all the security controls added by Builder in AuthorizationRoles. That is why we manually implemented the pagination object.