### PR TITLE
feat: NATS real-time event system with auth callout, mTLS and model publishing

### DIFF
--- a/src/Console/Commands/NatsAuthListenerCommand.php
+++ b/src/Console/Commands/NatsAuthListenerCommand.php
@@ -77,12 +77,16 @@ class NatsAuthListenerCommand extends Command
         try {
             $client = $this->connect();
 
+            // Queue subscription — only ONE instance handles each auth request when
+            // multiple containers are running. Without this, all instances reply and
+            // NATS receives duplicate responses to the same inbox.
             // The library's processMsg auto-replies with the callback's return value.
             // We MUST return the JWT rather than calling publish() manually — otherwise
             // the library sends a second empty message to the same replyTo, which
             // overwrites the valid JWT and causes NATS to reject the auth response.
-            $client->subscribe(
+            $client->subscribeQueue(
                 '$SYS.REQ.USER.AUTH',
+                'nats-auth-callout',
                 function (\Basis\Nats\Message\Payload $payload, ?string $replyTo) use ($authService) {
                     $requestJwt = $payload->body;
 

--- a/src/Console/Commands/NatsAuthListenerCommand.php
+++ b/src/Console/Commands/NatsAuthListenerCommand.php
@@ -21,6 +21,9 @@ use NextDeveloper\Events\Services\NatsAuthCalloutService;
  *   NATS_ACCOUNT_NKEY_PUBLIC=AAAA...
  *   NATS_ACCOUNT_NKEY_SEED=SAAA...
  *   NATS_AUTH_SERVICE_PASSWORD=strong-password
+ *   NATS_TLS_CA=storage/nats-ca.crt
+ *   NATS_TLS_CERT=storage/platform.leo4.crt
+ *   NATS_TLS_KEY=storage/platform.leo4.key
  *
  * Supervisor config (same pattern as events:nats-listen):
  *   [program:nats-auth]
@@ -32,6 +35,9 @@ class NatsAuthListenerCommand extends Command
     protected $description = 'NATS auth callout service — validates credentials for every NATS connection';
 
     private bool $shouldQuit = false;
+
+    // Seconds to wait before attempting to reconnect after a dropped connection
+    private const RECONNECT_DELAY = 3;
 
     public function handle(NatsAuthCalloutService $authService): int
     {
@@ -52,7 +58,62 @@ class NatsAuthListenerCommand extends Command
 
         $this->registerSignalHandlers();
 
-        // Connect as the auth-service account — this user bypasses the callout
+        while (!$this->shouldQuit) {
+            $this->runSession($authService);
+
+            if (!$this->shouldQuit) {
+                Log::warning('[NatsAuthListener] Reconnecting in ' . self::RECONNECT_DELAY . 's...');
+                $this->warn('NATS connection lost — reconnecting in ' . self::RECONNECT_DELAY . 's...');
+                sleep(self::RECONNECT_DELAY);
+            }
+        }
+
+        $this->info('NATS auth listener stopped.');
+        return 0;
+    }
+
+    private function runSession(NatsAuthCalloutService $authService): void
+    {
+        try {
+            $client = $this->connect();
+
+            // The library's processMsg auto-replies with the callback's return value.
+            // We MUST return the JWT rather than calling publish() manually — otherwise
+            // the library sends a second empty message to the same replyTo, which
+            // overwrites the valid JWT and causes NATS to reject the auth response.
+            $client->subscribe(
+                '$SYS.REQ.USER.AUTH',
+                function (\Basis\Nats\Message\Payload $payload, ?string $replyTo) use ($authService) {
+                    $requestJwt = $payload->body;
+
+                    if (!$replyTo) {
+                        Log::warning('[NatsAuthListener] Auth request has no replyTo subject');
+                        return null;
+                    }
+
+                    try {
+                        return $authService->handle($requestJwt);
+                    } catch (\Throwable $e) {
+                        Log::error('[NatsAuthListener] Exception during auth', ['error' => $e->getMessage()]);
+                        return $authService->handle('');
+                    }
+                }
+            );
+
+            $this->info('NATS auth callout service is listening on $SYS.REQ.USER.AUTH');
+
+            while (!$this->shouldQuit) {
+                $client->process(0.1);
+                pcntl_signal_dispatch();
+            }
+        } catch (\Throwable $e) {
+            Log::error('[NatsAuthListener] Connection error', ['error' => $e->getMessage()]);
+            $this->error('[NatsAuthListener] ' . $e->getMessage());
+        }
+    }
+
+    private function connect(): Client
+    {
         $config = [
             'host' => config('events.nats.server_host', '127.0.0.1'),
             'port' => (int) config('events.nats.server_port', 4222),
@@ -60,48 +121,19 @@ class NatsAuthListenerCommand extends Command
             'pass' => (string) config('events.nats.auth_service_password'),
         ];
 
-        // The basis-company/nats library does not support sending client certs
-        // when TLS is required by the server (it always calls enableTls(false)).
-        // Authentication is handled by user/pass via the auth callout instead.
         if (config('events.nats.tls_ca')) {
             $config['tlsCaFile'] = $this->resolvePath(config('events.nats.tls_ca'));
         }
 
-        $client = new Client(new Configuration($config));
-
-        // Subscribe to the NATS auth callout subject
-        // The library's processMsg auto-replies with the callback's return value.
-        // We MUST return the JWT rather than calling publish() manually — otherwise
-        // the library sends a second empty message to the same replyTo, which
-        // overwrites the valid JWT and causes NATS to reject the auth response.
-        $client->subscribe(
-            '$SYS.REQ.USER.AUTH',
-            function (\Basis\Nats\Message\Payload $payload, ?string $replyTo) use ($authService) {
-                $requestJwt = $payload->body;
-
-                if (!$replyTo) {
-                    Log::warning('[NatsAuthListener] Auth request has no replyTo subject');
-                    return null;
-                }
-
-                try {
-                    return $authService->handle($requestJwt);
-                } catch (\Throwable $e) {
-                    Log::error('[NatsAuthListener] Exception during auth', ['error' => $e->getMessage()]);
-                    return $authService->handle('');
-                }
-            }
-        );
-
-        $this->info('NATS auth callout service is listening on $SYS.REQ.USER.AUTH');
-
-        while (!$this->shouldQuit) {
-            $client->process(0.1);
-            pcntl_signal_dispatch();
+        if (config('events.nats.tls_cert')) {
+            $config['tlsCertFile'] = $this->resolvePath(config('events.nats.tls_cert'));
         }
 
-        $this->info('NATS auth listener stopped.');
-        return 0;
+        if (config('events.nats.tls_key')) {
+            $config['tlsKeyFile'] = $this->resolvePath(config('events.nats.tls_key'));
+        }
+
+        return new Client(new Configuration($config));
     }
 
     private function resolvePath(?string $path): ?string

--- a/src/Jobs/NatsPublisherJob.php
+++ b/src/Jobs/NatsPublisherJob.php
@@ -10,18 +10,31 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use League\Fractal\Manager;
+use League\Fractal\Resource\Item;
 use NextDeveloper\Events\Services\NatsService;
 
 /**
  * Publishes a model event to NATS so browser clients (via NATS WebSocket)
- * and other subscribers can receive real-time updates.
+ * can receive real-time updates.
  *
- * Subjects published:
- *   account.events.{account_uuid}                        — all events for the account
- *   account.events.{account_uuid}.{model_slug}           — filtered by model type
+ * Published subject:
+ *   client.{account_uuid}.evt
  *
- * Register this job as a listener via:
- *   Events::listen('updated:NextDeveloper\IAAS\ComputeMembers', NatsPublisherJob::class);
+ * Payload:
+ *   {
+ *     "event":       "created:NextDeveloper\IAAS\VirtualMachines",
+ *     "object_type": "NextDeveloper\IAAS\Database\Models\VirtualMachines",
+ *     "object":      { ...transformer output... }
+ *   }
+ *
+ * The transformer is resolved automatically from the model class name:
+ *   NextDeveloper\IAAS\Database\Models\VirtualMachines
+ *   → NextDeveloper\IAAS\Http\Transformers\VirtualMachinesTransformer
+ *
+ * Falls back to toArray() if no transformer exists for the model.
+ *
+ * Dispatched automatically by Events::fire() when NATS is enabled.
  */
 class NatsPublisherJob implements ShouldQueue
 {
@@ -48,25 +61,55 @@ class NatsPublisherJob implements ShouldQueue
 
         $payload = $this->buildPayload($accountUuid);
 
-        // Broad subject — browser subscribes to this for all account events
-        $nats->publish("account.events.{$accountUuid}", $payload);
+        $nats->publish("client.{$accountUuid}.evt", $payload);
 
-        // Narrower subject — allows filtering by model type
-        $modelSlug = $this->modelSlug();
-        $nats->publish("account.events.{$accountUuid}.{$modelSlug}", $payload);
+        Log::debug('[NatsPublisherJob] Published', [
+            'subject' => "client.{$accountUuid}.evt",
+            'event'   => $this->params['event'] ?? null,
+            'model'   => class_basename($this->model),
+        ]);
     }
 
     private function buildPayload(string $accountUuid): array
     {
         return [
-            'event'        => $this->params['event'] ?? null,
-            'model'        => class_basename($this->model),
-            'model_class'  => get_class($this->model),
-            'uuid'         => $this->model->uuid ?? null,
-            'account_uuid' => $accountUuid,
-            'data'         => $this->model->toArray(),
-            'fired_at'     => now()->toIso8601String(),
+            'event'       => $this->params['event'] ?? null,
+            'object_type' => get_class($this->model),
+            'object'      => $this->transformModel(),
         ];
+    }
+
+    private function transformModel(): array
+    {
+        $transformerClass = $this->resolveTransformerClass();
+
+        if ($transformerClass) {
+            try {
+                $manager  = new Manager();
+                $resource = new Item($this->model, new $transformerClass());
+                $data     = $manager->createData($resource)->toArray();
+
+                return $data['data'] ?? $this->model->toArray();
+            } catch (\Throwable $e) {
+                Log::warning('[NatsPublisherJob] Transformer failed, falling back to toArray', [
+                    'transformer' => $transformerClass,
+                    'error'       => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $this->model->toArray();
+    }
+
+    private function resolveTransformerClass(): ?string
+    {
+        $modelClass = get_class($this->model);
+
+        // NextDeveloper\IAAS\Database\Models\VirtualMachines
+        // → NextDeveloper\IAAS\Http\Transformers\VirtualMachinesTransformer
+        $transformerClass = str_replace('Database\\Models\\', 'Http\\Transformers\\', $modelClass) . 'Transformer';
+
+        return class_exists($transformerClass) ? $transformerClass : null;
     }
 
     private function resolveAccountUuid(): ?string
@@ -77,15 +120,8 @@ class NatsPublisherJob implements ShouldQueue
             return null;
         }
 
-        // Use DB directly to avoid pulling the full IAM model dependency
         return DB::table('iam_accounts')
             ->where('id', $accountId)
             ->value('uuid');
-    }
-
-    private function modelSlug(): string
-    {
-        // "NextDeveloper\IAAS\ComputeMembers" → "compute-members"
-        return \Illuminate\Support\Str::kebab(class_basename($this->model));
     }
 }

--- a/src/Services/Events.php
+++ b/src/Services/Events.php
@@ -5,6 +5,7 @@ namespace NextDeveloper\Events\Services;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use NextDeveloper\Events\Jobs\NatsPublisherJob;
 
 class Events
 {
@@ -40,6 +41,12 @@ class Events
         $listeners = DB::select('SELECT * FROM event_listeners WHERE event = ?', [$eventName]);
 
         $params = ['event' => $eventName];
+
+        // Push the transformed model to the account's NATS subject so browser
+        // clients receive real-time updates without registering a listener.
+        if (config('events.nats.enabled', false)) {
+            NatsPublisherJob::dispatch($model, $params);
+        }
 
         foreach ($listeners as $listener) {
             $job = $listener->callback;

--- a/src/Services/NatsAuthCalloutService.php
+++ b/src/Services/NatsAuthCalloutService.php
@@ -97,15 +97,24 @@ class NatsAuthCalloutService
         if ($oauthCandidate) {
             $result = $this->resolveOAuthToken($oauthCandidate);
             if ($result) {
-                ['account_uuid' => $accountUuid, 'user_uuid' => $userUuid] = $result;
+                ['account_uuids' => $accountUuids, 'user_uuid' => $userUuid] = $result;
 
-                Log::info('[NatsAuthCallout] Authenticated client', ['account' => $accountUuid]);
+                Log::info('[NatsAuthCallout] Authenticated client', [
+                    'accounts' => $accountUuids,
+                    'user'     => $userUuid,
+                ]);
 
-                return $this->allow($serverNKey, $userNKey, $accountUuid, [
-                    'sub' => [
-                        "client.{$accountUuid}.evt",
-                        "client.{$accountUuid}.{$userUuid}.evt",
-                    ],
+                // Allow the client to subscribe to every account they belong to.
+                // This means an account switch (toggling iam_account_users.is_active)
+                // does not require a NATS reconnect.
+                $subs = [];
+                foreach ($accountUuids as $accountUuid) {
+                    $subs[] = "client.{$accountUuid}.evt";
+                    $subs[] = "client.{$accountUuid}.{$userUuid}.evt";
+                }
+
+                return $this->allow($serverNKey, $userNKey, $accountUuids[0], [
+                    'sub' => $subs,
                     'pub' => [],
                 ]);
             }
@@ -160,6 +169,10 @@ class NatsAuthCalloutService
 
     /**
      * Resolve an OAuth access token against the oauth_access_tokens table.
+     *
+     * Returns all account UUIDs the user belongs to so that account switching
+     * (toggling is_active in iam_account_users) does not require a reconnect —
+     * the client is already permitted on every account's subject.
      */
     private function resolveOAuthToken(string $token): ?array
     {
@@ -173,15 +186,26 @@ class NatsAuthCalloutService
             return null;
         }
 
-        $accountUuid = DB::table('iam_accounts')
-            ->where('id', $row->account_id)
-            ->value('uuid');
-
         $userUuid = DB::table('iam_users')
             ->where('id', $row->user_id)
             ->value('uuid') ?? 'unknown';
 
-        return $accountUuid ? ['account_uuid' => $accountUuid, 'user_uuid' => $userUuid] : null;
+        // Collect all accounts this user is a member of, not just the active one.
+        // This allows the client to subscribe to any account's subject after switching
+        // without needing to reconnect.
+        $accountUuids = DB::table('iam_account_user')
+            ->join('iam_accounts', 'iam_accounts.id', '=', 'iam_account_user.iam_account_id')
+            ->where('iam_account_user.iam_user_id', $row->user_id)
+            ->pluck('iam_accounts.uuid')
+            ->filter()
+            ->values()
+            ->all();
+
+        if (empty($accountUuids)) {
+            return null;
+        }
+
+        return ['account_uuids' => $accountUuids, 'user_uuid' => $userUuid];
     }
 
     private function allow(string $serverNKey, string $userNKey, string $identifier, array $permissions): string

--- a/src/Services/NatsService.php
+++ b/src/Services/NatsService.php
@@ -77,16 +77,15 @@ class NatsService
     {
         if ($this->client === null) {
             // Only include keys with non-null values — typed properties reject null
-            // Note: basis-company/nats does not support mTLS when server sends tls_required.
-            // The library always calls enableTls(false), skipping client cert.
-            // Authentication is handled via user/pass + auth callout.
             $config = array_filter([
-                'host'      => config('events.nats.server_host', '127.0.0.1'),
-                'port'      => (int) config('events.nats.server_port', 4222),
-                'token'     => config('events.nats.token'),
-                'user'      => config('events.nats.user'),
-                'pass'      => config('events.nats.password'),
-                'tlsCaFile' => self::resolvePath(config('events.nats.tls_ca')),
+                'host'        => config('events.nats.server_host', '127.0.0.1'),
+                'port'        => (int) config('events.nats.server_port', 4222),
+                'token'       => config('events.nats.token'),
+                'user'        => config('events.nats.user'),
+                'pass'        => config('events.nats.password'),
+                'tlsCaFile'   => self::resolvePath(config('events.nats.tls_ca')),
+                'tlsCertFile' => self::resolvePath(config('events.nats.tls_cert')),
+                'tlsKeyFile'  => self::resolvePath(config('events.nats.tls_key')),
             ], fn ($v) => $v !== null && $v !== '');
 
             // Restore port — it could be filtered if it's 0

--- a/src/Services/NatsService.php
+++ b/src/Services/NatsService.php
@@ -76,13 +76,13 @@ class NatsService
     private function client(): Client
     {
         if ($this->client === null) {
-            // Only include keys with non-null values — typed properties reject null
+            // Connect as auth-service — this user bypasses the auth callout,
+            // giving the platform full publish access to any subject.
             $config = array_filter([
                 'host'        => config('events.nats.server_host', '127.0.0.1'),
                 'port'        => (int) config('events.nats.server_port', 4222),
-                'token'       => config('events.nats.token'),
-                'user'        => config('events.nats.user'),
-                'pass'        => config('events.nats.password'),
+                'user'        => 'auth-service',
+                'pass'        => config('events.nats.auth_service_password'),
                 'tlsCaFile'   => self::resolvePath(config('events.nats.tls_ca')),
                 'tlsCertFile' => self::resolvePath(config('events.nats.tls_cert')),
                 'tlsKeyFile'  => self::resolvePath(config('events.nats.tls_key')),


### PR DESCRIPTION
## Summary

- **Auth callout service**: `NatsAuthCalloutService` validates every NATS connection via `$SYS.REQ.USER.AUTH`. Agents authenticated via `events_token` (compute/storage/network), browser clients via OAuth tokens. Returns NKey-signed two-layer JWTs with scoped pub/sub permissions.
- **NkeyHelper**: Ed25519 NKey encoding, JWT signing, and base32 utilities — no external NKey library dependency.
- **Platform mTLS**: `NatsService` and `NatsAuthListenerCommand` both present `NATS_TLS_CERT`/`NATS_TLS_KEY` client certificates for mTLS on port 4222.
- **Auth listener**: `NatsAuthListenerCommand` uses `subscribeQueue` (queue group `nats-auth-callout`) so multiple container instances share load without duplicate responses. Reconnects automatically on connection drop.
- **Model event publishing**: `Events::fire()` auto-dispatches `NatsPublisherJob` when NATS is enabled. Job resolves Fractal transformer from model class name, transforms the model, publishes to `client.{account_uuid}.evt`.
- **Multi-account subscriptions**: OAuth clients get `client.{uuid}.evt` for every account in `iam_account_user` — account switching doesn't require reconnect.
- **NatsService**: Connects as `auth-service` (bypasses callout) for platform publish access.

## Test plan

- [ ] Connect browser client with OAuth token — confirm auth succeeds
- [ ] Subscribe to `client.{account_uuid}.evt` and trigger a model update — confirm transformed payload arrives
- [ ] Verify `events_token` agent connections get scoped permissions
- [ ] Run two instances and confirm only one handles each auth request (queue group)
- [ ] Confirm anonymous connections are rejected with `Invalid credentials`

🤖 Generated with [Claude Code](https://claude.com/claude-code)