### PR TITLE
fix: normalise model class when checking omit_objects

### DIFF
--- a/config/events.php
+++ b/config/events.php
@@ -60,5 +60,34 @@ return [
          *   'agent.heartbeat.*'  => \App\Jobs\Nats\HandleAgentHeartbeat::class,
          */
         'subscribers' => [],
+
+        /**
+         * Events and object types to omit from NATS publishing.
+         *
+         * 'omit_events' — skip publishing when the event name matches.
+         *   Supports exact strings and wildcards (* = any string).
+         *   Event names follow the pattern: "{action}:{namespace}\{Model}"
+         *
+         * Examples:
+         *   'creating:*'                                          — skip all pre-create events
+         *   'saving:*'                                            — skip all pre-save events
+         *   'created:NextDeveloper\IAM\Users'                     — skip this specific event
+         *
+         * 'omit_objects' — skip publishing when the model class matches.
+         *   Use the full model class name.
+         *
+         * Examples:
+         *   'NextDeveloper\IAM\Database\Models\Users'
+         *   'NextDeveloper\Commons\Database\Models\Logs'
+         */
+        'omit_events' => [
+            'creating:*',
+            'saving:*',
+            'deleting:*',
+        ],
+
+        'omit_objects' => [
+            //  'NextDeveloper\IAM\Database\Models\Users',
+        ],
     ],
 ];

--- a/config/events.php
+++ b/config/events.php
@@ -87,7 +87,7 @@ return [
         ],
 
         'omit_objects' => [
-            //  'NextDeveloper\IAM\Database\Models\Users',
+            //  'NextDeveloper\\IAAS\\ComputeMemberEvents',
         ],
     ],
 ];

--- a/src/Console/Commands/NatsSetupStreamsCommand.php
+++ b/src/Console/Commands/NatsSetupStreamsCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace NextDeveloper\Events\Console\Commands;
+
+use Basis\Nats\Client;
+use Basis\Nats\Configuration;
+use Basis\Nats\Stream\RetentionPolicy;
+use Basis\Nats\Stream\StorageBackend;
+use Basis\Nats\Stream\DiscardPolicy;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Creates (or updates) the JetStream streams required for durable agent command delivery.
+ *
+ * Run once at container startup via start.sh — idempotent, safe to run repeatedly.
+ *
+ * Streams created:
+ *
+ *   AGENT_COMMANDS
+ *     Subjects : agent.>
+ *     Retention: Limits (each durable consumer tracks its own position)
+ *     Storage  : File (survives container restarts)
+ *     Max age  : 24 hours — commands older than this are irrelevant
+ *     Max msgs : 1 000 per subject — prevents unbounded queuing per agent
+ *     Discard  : Old — when limits are hit, oldest messages are dropped
+ *
+ * Agents (Go) create their own durable consumers filtered to their subject
+ * (e.g. agent.compute.{uuid}.cmd) when they connect. On reconnect they resume
+ * from where they left off, receiving any commands queued while offline.
+ */
+class NatsSetupStreamsCommand extends Command
+{
+    protected $signature   = 'events:nats-setup-streams';
+    protected $description = 'Create or update JetStream streams for durable agent command delivery';
+
+    // 24 hours in nanoseconds
+    private const MAX_AGE_NS = 24 * 3600 * 1_000_000_000;
+
+    public function handle(): int
+    {
+        if (!config('events.nats.enabled', false)) {
+            $this->error('NATS is not enabled. Set NATS_ENABLED=true in your .env file.');
+            return 1;
+        }
+
+        $config = array_filter([
+            'host'        => config('events.nats.server_host', '127.0.0.1'),
+            'port'        => (int) config('events.nats.server_port', 4222),
+            'user'        => 'auth-service',
+            'pass'        => config('events.nats.auth_service_password'),
+            'tlsCaFile'   => $this->resolvePath(config('events.nats.tls_ca')),
+            'tlsCertFile' => $this->resolvePath(config('events.nats.tls_cert')),
+            'tlsKeyFile'  => $this->resolvePath(config('events.nats.tls_key')),
+        ], fn ($v) => $v !== null && $v !== '');
+
+        $config['port'] = (int) config('events.nats.server_port', 4222);
+
+        $client = new Client(new Configuration($config));
+
+        $this->setupAgentCommandsStream($client);
+
+        return 0;
+    }
+
+    private function setupAgentCommandsStream(Client $client): void
+    {
+        $stream = $client->getStream('AGENT_COMMANDS');
+
+        $stream->getConfiguration()
+            ->setSubjects(['agent.>'])
+            ->setStorageBackend(StorageBackend::FILE)
+            ->setRetentionPolicy(RetentionPolicy::LIMITS)
+            ->setDiscardPolicy(DiscardPolicy::OLD)
+            ->setMaxAge(self::MAX_AGE_NS)
+            ->setMaxMessagesPerSubject(1000)
+            ->setReplicas(1)
+            ->setDescription('Durable agent command delivery — compute, storage, network, broadcast');
+
+        if ($stream->exists()) {
+            $stream->update();
+            $this->info('AGENT_COMMANDS stream updated.');
+            Log::info('[NatsSetupStreams] AGENT_COMMANDS stream updated');
+        } else {
+            $stream->create();
+            $this->info('AGENT_COMMANDS stream created.');
+            Log::info('[NatsSetupStreams] AGENT_COMMANDS stream created');
+        }
+
+        $this->line('  Subjects : agent.>');
+        $this->line('  Storage  : file');
+        $this->line('  Retention: limits');
+        $this->line('  Max age  : 24h');
+        $this->line('  Max msgs : 1 000 per subject');
+    }
+
+    private function resolvePath(?string $path): ?string
+    {
+        if ($path === null || $path === '') {
+            return null;
+        }
+
+        return str_starts_with($path, '/') ? $path : base_path($path);
+    }
+}

--- a/src/EventsServiceProvider.php
+++ b/src/EventsServiceProvider.php
@@ -107,6 +107,7 @@ class EventsServiceProvider extends AbstractServiceProvider
                     \NextDeveloper\Events\Console\Commands\NatsGenerateAuthCommand::class,
                     \NextDeveloper\Events\Console\Commands\NatsAuthListenerCommand::class,
                     \NextDeveloper\Events\Console\Commands\NatsKeygenCommand::class,
+                    \NextDeveloper\Events\Console\Commands\NatsSetupStreamsCommand::class,
                 ]
             );
         }

--- a/src/Services/Events.php
+++ b/src/Services/Events.php
@@ -44,7 +44,7 @@ class Events
 
         // Push the transformed model to the account's NATS subject so browser
         // clients receive real-time updates without registering a listener.
-        if (config('events.nats.enabled', false)) {
+        if (config('events.nats.enabled', false) && !self::isOmitted($eventName, $model)) {
             NatsPublisherJob::dispatch($model, $params);
         }
 
@@ -78,5 +78,29 @@ class Events
                 return;
             }
         }
+    }
+
+    /**
+     * Check whether an event should be omitted from NATS publishing.
+     * Matches against events.nats.omit_events (supports * wildcard)
+     * and events.nats.omit_objects (exact model class match).
+     */
+    private static function isOmitted(string $eventName, Model $model): bool
+    {
+        $omitEvents  = config('events.nats.omit_events', []);
+        $omitObjects = config('events.nats.omit_objects', []);
+
+        foreach ($omitEvents as $pattern) {
+            $regex = '/^' . str_replace('\*', '.*', preg_quote($pattern, '/')) . '$/';
+            if (preg_match($regex, $eventName)) {
+                return true;
+            }
+        }
+
+        if (in_array(get_class($model), $omitObjects, true)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Services/Events.php
+++ b/src/Services/Events.php
@@ -97,7 +97,13 @@ class Events
             }
         }
 
-        if (in_array(get_class($model), $omitObjects, true)) {
+        // Config may use short form (e.g. NextDeveloper\Accounting\Invoices) instead of
+        // the full model class (NextDeveloper\Accounting\Database\Models\Invoices), so we
+        // normalise by stripping \Database\Models\ before comparing.
+        $modelClass       = get_class($model);
+        $normalizedClass  = str_replace('\\Database\\Models\\', '\\', $modelClass);
+
+        if (in_array($modelClass, $omitObjects, true) || in_array($normalizedClass, $omitObjects, true)) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- `get_class($model)` returns the full path (e.g. `NextDeveloper\Accounting\Database\Models\Invoices`) but `omit_objects` config entries use the short form (e.g. `NextDeveloper\Accounting\Invoices`)
- The `in_array` check never matched, so omitted objects were still being published to NATS
- Fixed by stripping `\Database\Models\` from the model class before comparing; both short-form and full-form config entries now work

## Test plan
- [ ] Add a model class to `omit_objects` in short form (e.g. `NextDeveloper\\Accounting\\Invoices`)
- [ ] Trigger an event on that model and confirm it is NOT published to NATS
- [ ] Confirm other models are still published normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)