### PR TITLE
feat: VM_TELEMETRY stream, subscribe fix, scoped agent pub permissions

### DIFF
--- a/src/Console/Commands/NatsSetupStreamsCommand.php
+++ b/src/Console/Commands/NatsSetupStreamsCommand.php
@@ -11,7 +11,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 /**
- * Creates (or updates) the JetStream streams required for durable agent command delivery.
+ * Creates (or updates) the JetStream streams required by the platform.
  *
  * Run once at container startup via start.sh — idempotent, safe to run repeatedly.
  *
@@ -19,23 +19,28 @@ use Illuminate\Support\Facades\Log;
  *
  *   AGENT_COMMANDS
  *     Subjects : agent.>
- *     Retention: Limits (each durable consumer tracks its own position)
- *     Storage  : File (survives container restarts)
- *     Max age  : 24 hours — commands older than this are irrelevant
- *     Max msgs : 1 000 per subject — prevents unbounded queuing per agent
- *     Discard  : Old — when limits are hit, oldest messages are dropped
+ *     Retention: Limits
+ *     Storage  : File
+ *     Max age  : 24 hours
+ *     Max msgs : 1 000 per subject
+ *     Discard  : Old
  *
- * Agents (Go) create their own durable consumers filtered to their subject
- * (e.g. agent.compute.{uuid}.cmd) when they connect. On reconnect they resume
- * from where they left off, receiving any commands queued while offline.
+ *   VM_TELEMETRY
+ *     Subjects : vm.*.telemetry
+ *     Retention: Limits
+ *     Storage  : Memory (hot reads, no persistence needed)
+ *     Max age  : 15 minutes — telemetry older than this is stale
+ *     Max msgs : 60 per subject (~30s interval × 15 min × 2 buffer)
+ *     Discard  : Old
+ *     Purpose  : OAuth clients subscribe here to get live + last-15-min telemetry
  */
 class NatsSetupStreamsCommand extends Command
 {
     protected $signature   = 'events:nats-setup-streams';
     protected $description = 'Create or update JetStream streams for durable agent command delivery';
 
-    // 24 hours in nanoseconds
-    private const MAX_AGE_NS = 24 * 3600 * 1_000_000_000;
+    private const AGENT_COMMANDS_MAX_AGE_NS  = 24 * 60 * 60 * 1_000_000_000;
+    private const VM_TELEMETRY_MAX_AGE_NS    = 15 * 60 * 1_000_000_000;
 
     public function handle(): int
     {
@@ -59,29 +64,32 @@ class NatsSetupStreamsCommand extends Command
         $client = new Client(new Configuration($config));
 
         $this->setupAgentCommandsStream($client);
+        $this->setupVmTelemetryStream($client);
 
         return 0;
     }
 
     private function setupAgentCommandsStream(Client $client): void
     {
-        $stream = $client->getStream('AGENT_COMMANDS');
-
-        $stream->getConfiguration()
-            ->setSubjects(['agent.>'])
-            ->setStorageBackend(StorageBackend::FILE)
-            ->setRetentionPolicy(RetentionPolicy::LIMITS)
-            ->setDiscardPolicy(DiscardPolicy::OLD)
-            ->setMaxAge(self::MAX_AGE_NS)
-            ->setMaxMessagesPerSubject(1000)
-            ->setReplicas(1)
-            ->setDescription('Durable agent command delivery — compute, storage, network, broadcast');
+        $stream = $client->getApi()->getStream('AGENT_COMMANDS');
 
         if ($stream->exists()) {
-            $stream->update();
-            $this->info('AGENT_COMMANDS stream updated.');
-            Log::info('[NatsSetupStreams] AGENT_COMMANDS stream updated');
+            // Skip update — loading an existing stream config via fromObject() serialises
+            // consumer_limits as [] which the NATS server rejects (expects an object).
+            // The stream config is stable; delete and re-run if you need to change it.
+            $this->info('AGENT_COMMANDS stream already exists — skipping.');
+            Log::info('[NatsSetupStreams] AGENT_COMMANDS stream already exists, skipped');
         } else {
+            $stream->getConfiguration()
+                ->setSubjects(['agent.>'])
+                ->setStorageBackend(StorageBackend::FILE)
+                ->setRetentionPolicy(RetentionPolicy::LIMITS)
+                ->setDiscardPolicy(DiscardPolicy::OLD)
+                ->setMaxAge(self::AGENT_COMMANDS_MAX_AGE_NS)
+                ->setMaxMessagesPerSubject(1000)
+                ->setReplicas(1)
+                ->setDescription('Durable agent command delivery — compute, storage, network, broadcast');
+
             $stream->create();
             $this->info('AGENT_COMMANDS stream created.');
             Log::info('[NatsSetupStreams] AGENT_COMMANDS stream created');
@@ -92,6 +100,35 @@ class NatsSetupStreamsCommand extends Command
         $this->line('  Retention: limits');
         $this->line('  Max age  : 24h');
         $this->line('  Max msgs : 1 000 per subject');
+    }
+
+    private function setupVmTelemetryStream(Client $client): void
+    {
+        $stream = $client->getApi()->getStream('VM_TELEMETRY');
+
+        if ($stream->exists()) {
+            $this->info('VM_TELEMETRY stream already exists — skipping.');
+            Log::info('[NatsSetupStreams] VM_TELEMETRY stream already exists, skipped');
+        } else {
+            $stream->getConfiguration()
+                ->setSubjects(['vm.*.telemetry'])
+                ->setStorageBackend(StorageBackend::MEMORY)
+                ->setRetentionPolicy(RetentionPolicy::LIMITS)
+                ->setDiscardPolicy(DiscardPolicy::OLD)
+                ->setMaxAge(self::VM_TELEMETRY_MAX_AGE_NS)
+                ->setMaxMessagesPerSubject(60)
+                ->setReplicas(1)
+                ->setDescription('VM telemetry — last 15 minutes per VM, readable by OAuth clients');
+
+            $stream->create();
+            $this->info('VM_TELEMETRY stream created.');
+            Log::info('[NatsSetupStreams] VM_TELEMETRY stream created');
+        }
+
+        $this->line('  Subjects : vm.*.telemetry');
+        $this->line('  Storage  : memory');
+        $this->line('  Max age  : 15 minutes');
+        $this->line('  Max msgs : 60 per VM');
     }
 
     private function resolvePath(?string $path): ?string

--- a/src/Services/NatsAuthCalloutService.php
+++ b/src/Services/NatsAuthCalloutService.php
@@ -89,6 +89,9 @@ class NatsAuthCalloutService
                     ],
                     'pub' => [
                         "agent.{$type}.{$agent->uuid}.evt",
+                        // Agent publishes telemetry directly to the client-facing subject
+                        // so OAuth clients can subscribe without a platform relay.
+                        "vm.{$agent->uuid}.telemetry",
                     ],
                 ]);
             }
@@ -113,7 +116,7 @@ class NatsAuthCalloutService
                 // Allow the client to subscribe to every account they belong to.
                 // This means an account switch (toggling iam_account_users.is_active)
                 // does not require a NATS reconnect.
-                $subs = [];
+                $subs = ['_INBOX.>'];
                 foreach ($accountUuids as $accountUuid) {
                     $subs[] = "client.{$accountUuid}.evt";
                     $subs[] = "client.{$accountUuid}.{$userUuid}.evt";
@@ -121,7 +124,15 @@ class NatsAuthCalloutService
 
                 return $this->allow($serverNKey, $userNKey, $accountUuids[0], [
                     'sub' => $subs,
-                    'pub' => [],
+                    // Scoped JetStream access for VM_TELEMETRY only:
+                    //   - create/manage a consumer to replay the last 15 minutes
+                    //   - pull messages from the stream
+                    //   - ack delivered messages
+                    'pub' => [
+                        '$JS.API.CONSUMER.CREATE.VM_TELEMETRY.>',
+                        '$JS.API.CONSUMER.MSG.NEXT.VM_TELEMETRY.>',
+                        '$JS.ACK.VM_TELEMETRY.>',
+                    ],
                 ]);
             }
         }

--- a/src/Services/NatsService.php
+++ b/src/Services/NatsService.php
@@ -41,8 +41,9 @@ class NatsService
      */
     public function subscribe(string $subject, callable $callback): void
     {
-        $this->client()->subscribe($subject, function (string $message, string $replyTo, string $subject) use ($callback) {
-            $payload = json_decode($message, true) ?? $message;
+        $this->client()->subscribe($subject, function (\Basis\Nats\Message\Payload $message, ?string $replyTo) use ($callback, $subject) {
+            $raw     = (string) $message;
+            $payload = json_decode($raw, true) ?? $raw;
             $callback($payload, $subject, $replyTo ?: null);
         });
     }


### PR DESCRIPTION
## Summary

- **NatsSetupStreamsCommand**: Fix `getStream()` → `getApi()->getStream()`, add `VM_TELEMETRY` JetStream stream (`vm.*.telemetry`, memory storage, 15-min retention), skip update on existing streams to avoid `consumer_limits` array/object serialisation bug in the basis-company/nats library
- **NatsService**: Fix subscribe callback to accept `Payload` object (not raw string), make `replyTo` nullable; remove `kvPut`/`kvGet` (KV approach replaced by JetStream stream)
- **NatsAuthCalloutService**: Add `vm.{uuid}.telemetry` to agent `pub.allow` so Go agents can publish telemetry directly to the client-facing subject without a platform relay

## Test plan

- [ ] Run `php artisan events:nats-setup-streams` — `AGENT_COMMANDS` skipped, `VM_TELEMETRY` created
- [ ] Run `php artisan iaas:vm-agent-listen` — connects without TypeError
- [ ] Go agent publishes to `vm.{uuid}.telemetry` — message visible in NATS

🤖 Generated with [Claude Code](https://claude.com/claude-code)