### PR TITLE
feat: grant OAuth clients subscribe permission to their VMs telemetry

### DIFF
--- a/src/Services/NatsAuthCalloutService.php
+++ b/src/Services/NatsAuthCalloutService.php
@@ -122,6 +122,12 @@ class NatsAuthCalloutService
                     $subs[] = "client.{$accountUuid}.{$userUuid}.evt";
                 }
 
+                // Allow the client to subscribe to live telemetry for every VM
+                // that belongs to any of their accounts.
+                foreach ($this->resolveVmUuids($accountUuids) as $vmUuid) {
+                    $subs[] = "vm.{$vmUuid}.telemetry";
+                }
+
                 return $this->allow($serverNKey, $userNKey, $accountUuids[0], [
                     'sub' => $subs,
                     // Scoped JetStream access for VM_TELEMETRY only:
@@ -223,6 +229,29 @@ class NatsAuthCalloutService
         }
 
         return ['account_uuids' => $accountUuids, 'user_uuid' => $userUuid];
+    }
+
+    /**
+     * Return all VM UUIDs belonging to the given accounts.
+     * Used to grant per-VM telemetry subscribe permissions to OAuth clients.
+     */
+    private function resolveVmUuids(array $accountUuids): array
+    {
+        if (empty($accountUuids)) {
+            return [];
+        }
+
+        $accountIds = DB::table('iam_accounts')
+            ->whereIn('uuid', $accountUuids)
+            ->pluck('id');
+
+        return DB::table('iaas_virtual_machines')
+            ->whereIn('iam_account_id', $accountIds)
+            ->whereNull('deleted_at')
+            ->pluck('uuid')
+            ->filter()
+            ->values()
+            ->all();
     }
 
     private function allow(string $serverNKey, string $userNKey, string $identifier, array $permissions): string


### PR DESCRIPTION
## Summary

- Add `resolveVmUuids(array $accountUuids): array` — queries `iaas_virtual_machines` for all VMs belonging to the user's accounts
- Add `vm.{uuid}.telemetry` to `sub.allow` for each VM at auth callout time
- Clients can now subscribe to live telemetry and replay the last 15 minutes from the `VM_TELEMETRY` JetStream stream
- Reconnect required when a new VM is added to the account (same behaviour as account switching)

## Test plan

- [ ] Connect via WebSocket with a valid OAuth token
- [ ] Subscribe to `vm.{uuid}.telemetry` for a VM in the account — messages received
- [ ] Subscribe to `vm.{other-account-uuid}.telemetry` — permission denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)