### PR TITLE
feat: add synchronous agent command service with inbox-based reply pattern

### DIFF
--- a/docs/agent-sync-command.md
+++ b/docs/agent-sync-command.md
@@ -1,0 +1,181 @@
+# Synchronous Agent Command Protocol
+
+## Overview
+
+The platform supports synchronous command-response with VM agents via `AgentCommandService::send()`.  
+The caller publishes a command and blocks until the agent replies or a timeout is reached.
+
+This requires one small update to the Go agent: honour the `reply_to` field in the command envelope.
+
+---
+
+## Why `reply_to` in the Payload (Not NATS Header)
+
+The `agent.vm.{uuid}.cmd` subject is backed by a **JetStream stream** (`AGENT_COMMANDS`).  
+When a NATS message is published with a `replyTo` header, **JetStream intercepts it and acks to that header immediately** — the platform receives the JetStream PubAck instead of the agent's result.
+
+To avoid this, the platform embeds the reply inbox inside the **payload** as `reply_to`.  
+The agent reads it and publishes the result directly to that subject.
+
+---
+
+## Protocol Flow
+
+```
+PHP (AgentCommandService)       JetStream            Go Agent
+        |                           |                    |
+        | subscribe(_INBOX.xyz)     |                    |
+        |                           |                    |
+        | publish(agent.vm.{uuid}.cmd)                   |
+        |   payload includes                             |
+        |   "reply_to": "_INBOX.xyz" --> deliver msg --> |
+        |                           |                    | execute operation
+        |                           |                    |
+        | <---- publish(_INBOX.xyz, result) ------------ |
+        |                           |
+        | return result to caller   |
+```
+
+---
+
+## Command Envelope (Received by Agent)
+
+```json
+{
+  "v": 1,
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "command",
+  "agent_type": "vm",
+  "agent_uuid": "d6199047-322a-4845-bdea-1d44dd1b49e5",
+  "timestamp": 1748000000,
+  "reply_to": "_INBOX.7f3a1c2d-...",
+  "payload": {
+    "operation": "services.get",
+    "params": {},
+    "timeout_s": 10
+  }
+}
+```
+
+`reply_to` is **optional**. When absent the agent uses its existing async result path.
+
+---
+
+## Result Envelope (Agent Must Send Back)
+
+```json
+{
+  "v": 1,
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "result",
+  "agent_type": "vm",
+  "agent_uuid": "d6199047-322a-4845-bdea-1d44dd1b49e5",
+  "timestamp": 1748000001,
+  "payload": {
+    "command_id": "550e8400-e29b-41d4-a716-446655440000",
+    "status": "completed",
+    "output": { }
+  }
+}
+```
+
+On error, set `"status": "error"` and put the error message in `output`.
+
+---
+
+## Changes Required in the Go Agent
+
+### 1. Add `ReplyTo` to the Command Envelope Struct
+
+```go
+type CommandEnvelope struct {
+    V         int            `json:"v"`
+    ID        string         `json:"id"`
+    Type      string         `json:"type"`
+    AgentType string         `json:"agent_type"`
+    AgentUUID string         `json:"agent_uuid"`
+    Timestamp int64          `json:"timestamp"`
+    ReplyTo   string         `json:"reply_to"`  // ← ADD THIS
+    Payload   CommandPayload `json:"payload"`
+}
+```
+
+### 2. Publish Result to `ReplyTo` When Present
+
+```go
+func (a *Agent) handleCommand(env CommandEnvelope) {
+    result, err := a.execute(env.Payload.Operation, env.Payload.Params)
+
+    status := "completed"
+    output := result
+
+    if err != nil {
+        status = "error"
+        output = map[string]string{"message": err.Error()}
+    }
+
+    response := ResultEnvelope{
+        V:         1,
+        ID:        env.ID,
+        Type:      "result",
+        AgentType: "vm",
+        AgentUUID: env.AgentUUID,
+        Timestamp: time.Now().Unix(),
+        Payload: ResultPayload{
+            CommandID: env.ID,
+            Status:    status,
+            Output:    output,
+        },
+    }
+
+    raw, _ := json.Marshal(response)
+
+    if env.ReplyTo != "" {
+        // Synchronous caller is waiting on this inbox — reply directly
+        a.nats.Publish(env.ReplyTo, raw)
+        return
+    }
+
+    // Async path — unchanged behaviour
+    a.nats.Publish(fmt.Sprintf("agent.vm.%s", env.AgentUUID), raw)
+}
+```
+
+> **Important:** The error path must also respect `reply_to`. If it does not publish on error, the PHP caller will hang until the `timeoutSeconds` expires.
+
+---
+
+## PHP Usage
+
+```php
+use NextDeveloper\Events\Services\AgentCommandService;
+use NextDeveloper\Events\Exceptions\AgentTimeoutException;
+
+try {
+    $result = app(AgentCommandService::class)->send(
+        agentUuid:      $vm->uuid,
+        operation:      'services.get',
+        params:         [],
+        timeoutSeconds: 10
+    );
+
+    // $result is the decoded payload from the agent
+} catch (AgentTimeoutException $e) {
+    // Agent did not reply within timeoutSeconds
+}
+```
+
+---
+
+## Summary of Changes
+
+| File / Area                  | Change                                                  |
+|------------------------------|---------------------------------------------------------|
+| Command envelope struct      | Add `ReplyTo string json:"reply_to"`                    |
+| Command handler — success    | Publish result to `env.ReplyTo` if set                  |
+| Command handler — error      | Publish error result to `env.ReplyTo` if set            |
+| JetStream consumer setup     | No change                                               |
+| Heartbeat / telemetry        | No change                                               |
+| Capabilities handler         | No change                                               |
+
+The async path (no `reply_to`) is completely untouched — existing behaviour is fully backward compatible.

--- a/src/Exceptions/AgentTimeoutException.php
+++ b/src/Exceptions/AgentTimeoutException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace NextDeveloper\Events\Exceptions;
+
+use RuntimeException;
+
+class AgentTimeoutException extends RuntimeException
+{
+}

--- a/src/Services/AgentCommandService.php
+++ b/src/Services/AgentCommandService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace NextDeveloper\Events\Services;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use NextDeveloper\Events\Exceptions\AgentTimeoutException;
+
+/**
+ * Sends a command to a VM agent over NATS and blocks until the agent replies.
+ *
+ * Uses the NATS request-reply (inbox) pattern so the caller gets a synchronous
+ * result, making it suitable for use inside automation pipelines.
+ *
+ * Protocol envelope sent to agent.vm.{uuid}.cmd:
+ * {
+ *   "v": 1, "id": "<uuid>", "type": "command", "agent_type": "vm",
+ *   "agent_uuid": "<vm-uuid>", "timestamp": <unix>,
+ *   "payload": { "operation": "<op>", "params": {}, "timeout_s": <n> }
+ * }
+ *
+ * The agent replies to the NATS inbox with the operation result.
+ */
+class AgentCommandService
+{
+    public function __construct(private readonly NatsService $nats)
+    {
+    }
+
+    /**
+     * Send a command to a VM agent and wait synchronously for the result.
+     *
+     * @param  string $agentUuid      VM UUID used as the agent identifier
+     * @param  string $operation      Operation name (e.g. 'agent.allowed_operations')
+     * @param  array  $params         Optional parameters for the operation
+     * @param  int    $timeoutSeconds Maximum seconds to wait for a reply
+     * @return array                  Result payload returned by the agent
+     * @throws AgentTimeoutException  If the agent does not reply within the timeout
+     */
+    public function send(string $agentUuid, string $operation, array $params = [], int $timeoutSeconds = 10): array
+    {
+        $commandId = (string) Str::uuid();
+        $subject   = "agent.vm.{$agentUuid}.cmd";
+
+        $envelope = [
+            'v'          => 1,
+            'id'         => $commandId,
+            'type'       => 'command',
+            'agent_type' => 'vm',
+            'agent_uuid' => $agentUuid,
+            'timestamp'  => time(),
+            'payload'    => [
+                'operation' => $operation,
+                'params'    => empty($params) ? (object) [] : $params,
+                'timeout_s' => $timeoutSeconds,
+            ],
+        ];
+
+        Log::info('[AgentCommandService] Sending command', [
+            'subject'    => $subject,
+            'command_id' => $commandId,
+            'operation'  => $operation,
+        ]);
+
+        $result = $this->nats->dispatch($subject, $envelope, (float) $timeoutSeconds);
+
+        Log::info('[AgentCommandService] Command result received', [
+            'command_id' => $commandId,
+            'operation'  => $operation,
+            'status'     => $result['status'] ?? 'unknown',
+        ]);
+
+        return $result;
+    }
+}

--- a/src/Services/NatsAuthCalloutService.php
+++ b/src/Services/NatsAuthCalloutService.php
@@ -92,6 +92,8 @@ class NatsAuthCalloutService
                         // Agent publishes telemetry directly to the client-facing subject
                         // so OAuth clients can subscribe without a platform relay.
                         "vm.{$agent->uuid}.telemetry",
+                        // Agent needs to publish to temporary inboxes for sync command replies
+                        "_INBOX.>",
                     ],
                 ]);
             }

--- a/src/Services/NatsService.php
+++ b/src/Services/NatsService.php
@@ -5,6 +5,8 @@ namespace NextDeveloper\Events\Services;
 use Basis\Nats\Client;
 use Basis\Nats\Configuration;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use NextDeveloper\Events\Exceptions\AgentTimeoutException;
 
 /**
  * Wraps the NATS client with lazy connection and config-driven setup.
@@ -80,6 +82,51 @@ class NatsService
                 'error'    => $e->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * Publish a command to a JetStream subject and block until the agent replies.
+     *
+     * Unlike the native NATS request-reply pattern, this method does NOT set a
+     * NATS replyTo header — that would cause JetStream to respond with a PubAck
+     * instead of the agent's result. Instead, the inbox subject is embedded in
+     * the payload as "reply_to" so the agent can publish its result there directly.
+     *
+     * @param  string $subject   Target subject (e.g. agent.vm.{uuid}.cmd)
+     * @param  array  $payload   Command envelope; "reply_to" will be injected automatically
+     * @param  float  $timeout   Seconds to wait for a reply
+     * @return array             Decoded reply payload from the agent
+     * @throws \NextDeveloper\Events\Exceptions\AgentTimeoutException
+     */
+    public function dispatch(string $subject, array $payload, float $timeout = 10.0): array
+    {
+        $inbox    = '_INBOX.' . Str::uuid()->toString();
+        $result   = null;
+        $deadline = microtime(true) + $timeout;
+
+        // Subscribe to our temporary inbox before publishing
+        $this->client()->subscribe($inbox, function (string $message) use (&$result) {
+            $result = json_decode($message, true) ?? [];
+        });
+
+        // Embed the inbox so the agent knows where to publish the result
+        $payload['reply_to'] = $inbox;
+
+        // Plain publish — no NATS replyTo header, avoids JetStream PubAck
+        $this->client()->publish($subject, json_encode($payload));
+
+        // Poll until the agent replies or we time out
+        while ($result === null && microtime(true) < $deadline) {
+            $this->client()->process(0.1);
+        }
+
+        if ($result === null) {
+            throw new AgentTimeoutException(
+                "Agent did not respond on [{$subject}] within {$timeout}s"
+            );
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `AgentCommandService::send()` for synchronous command-response with VM agents — builds the protocol envelope, blocks until the agent replies or timeout expires
- Add `NatsService::dispatch()` using payload-level `reply_to` (not NATS replyTo header) to avoid JetStream PubAck being returned as the result
- Add `AgentTimeoutException` thrown when the agent does not reply in time
- Grant agents publish permission to `_INBOX.>` in `NatsAuthCalloutService` so they can reply to the temporary inbox subject (merged with existing `vm.{uuid}.telemetry` permission)
- Add `docs/agent-sync-command.md` documenting the protocol and required Go agent changes

## Test plan
- [ ] Run `app(AgentCommandService::class)->send(agentUuid: '...', operation: 'services.get')` in Tinker and confirm result is returned
- [ ] Confirm `AgentTimeoutException` is thrown when agent is unreachable
- [ ] Confirm agents can still publish telemetry to `vm.{uuid}.telemetry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)