### PR TITLE
fix: accept Payload object in dispatch() inbox callback

### DIFF
--- a/src/Services/NatsService.php
+++ b/src/Services/NatsService.php
@@ -105,8 +105,9 @@ class NatsService
         $deadline = microtime(true) + $timeout;
 
         // Subscribe to our temporary inbox before publishing
-        $this->client()->subscribe($inbox, function (string $message) use (&$result) {
-            $result = json_decode($message, true) ?? [];
+        // The Basis NATS client passes a Payload object, not a raw string
+        $this->client()->subscribe($inbox, function (\Basis\Nats\Message\Payload|string $message) use (&$result) {
+            $result = json_decode((string) $message, true) ?? [];
         });
 
         // Embed the inbox so the agent knows where to publish the result


### PR DESCRIPTION
## Summary
`Basis\Nats\Client` passes a `Basis\Nats\Message\Payload` object (not a raw string) to subscribe callbacks. The `dispatch()` inbox callback had a `string` type hint which caused a `TypeError` at runtime. Fixed by accepting `Payload|string` and casting with `(string)` before JSON-decoding.

## Test plan
- [ ] Run `AgentCommandService::send()` in Tinker and confirm result is returned without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)