### PR TITLE
Add s3_servers and s3_backup_agents to NATS auth callout

### DIFF
--- a/src/Services/NatsAuthCalloutService.php
+++ b/src/Services/NatsAuthCalloutService.php
@@ -41,6 +41,11 @@ class NatsAuthCalloutService
         'iaas_storage_members' => 'storage',
         'iaas_network_members' => 'network',
         's3_servers'           => 's3',
+        // backup.agent — runs on an arbitrary customer machine, not a pre-provisioned
+        // member row baked with credentials ahead of time. Row is created `pending`
+        // when a registration token is issued, then flips to `active` with a live
+        // agent_api_key once BackupAgentsService::register() consumes the token.
+        's3_backup_agents'     => 'backup',
     ];
 
     /**

--- a/src/Services/NatsAuthCalloutService.php
+++ b/src/Services/NatsAuthCalloutService.php
@@ -40,6 +40,7 @@ class NatsAuthCalloutService
         'iaas_compute_members' => 'compute',
         'iaas_storage_members' => 'storage',
         'iaas_network_members' => 'network',
+        's3_servers'           => 's3',
     ];
 
     /**
@@ -81,20 +82,24 @@ class NatsAuthCalloutService
             if ($agent) {
                 Log::info('[NatsAuthCallout] Authenticated agent', ['type' => $type, 'uuid' => $agent->uuid]);
 
+                $pubSubjects = [
+                    "agent.{$type}.{$agent->uuid}.evt",
+                    "_INBOX.>",
+                ];
+
+                // VM agents publish live telemetry to a per-VM client-facing subject
+                // so OAuth browsers can subscribe without a platform relay.
+                if ($type === 'vm') {
+                    $pubSubjects[] = "vm.{$agent->uuid}.telemetry";
+                }
+
                 return $this->allow($serverNKey, $userNKey, $agent->uuid, [
                     'sub' => [
                         "agent.{$type}.{$agent->uuid}.cmd",
                         "agent.{$type}.broadcast",
                         "agent.broadcast",
                     ],
-                    'pub' => [
-                        "agent.{$type}.{$agent->uuid}.evt",
-                        // Agent publishes telemetry directly to the client-facing subject
-                        // so OAuth clients can subscribe without a platform relay.
-                        "vm.{$agent->uuid}.telemetry",
-                        // Agent needs to publish to temporary inboxes for sync command replies
-                        "_INBOX.>",
-                    ],
+                    'pub' => $pubSubjects,
                 ]);
             }
         }


### PR DESCRIPTION
## Summary
- `f153a21`: adds `s3_servers` to `AGENT_TABLES` in `NatsAuthCalloutService`, scopes pub permissions by agent type (already released as v1.2.3, tagged from `dev`)
- `fae443c`: adds `s3_backup_agents` => `backup` to the same map, so backup.agent's NATS connections authenticate through the existing generic lookup/grant logic (released as v1.2.4, also tagged from `dev`)

`master` was behind `dev` by both of these — this PR brings it current.

## Test plan
- [x] Verified live: after tagging v1.2.4, confirmed root cause (master never had `s3_backup_agents` in `AGENT_TABLES`) is what was blocking backup.agent's NATS auth